### PR TITLE
add quicklink to create new OpenAI key

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,6 +67,8 @@
               <div class="mt-6 text-sm text-gray-500">
                 API key is saved locally. You can clone the original repo and examine the code if you're unsure about entering your API key.
                 <a href="https://github.com/Troyanovsky/pm_doc_interrogator" class="underline">Original Repo</a>
+                If you already have an OpenAI account, you can quickly create a new API key at 
+                <a href="https://platform.openai.com/api-keys" class="underline">https://platform.openai.com/api-keys</a>.
               </div>
             </form>
           </div>


### PR DESCRIPTION
Hello! I was excited to try out this app and thought I'd contribute back.

This little trick has helped me in my own GPT apps: giving the reader quick access to the API key creation page. This also indirectly encourages them to create a unique name and expiration date (security benefits), rather than using an existing key in their password manager app.

Totally your call if you want to accept this but I thought I'd sent it your way since it was quick and easy to do.

FYI - I discovered this app from your Medium article: https://bootcamp.uxdesign.cc/how-i-built-a-tool-to-help-me-improve-product-documents-with-gpt-f5cb827e47bd